### PR TITLE
Sprint1 config 25

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ jdk:
 script: 
       - ./grailsw refresh-dependencies
       - ./grailsw test-app -coverage
+after_success:
+      - ./grailsw coveralls
 deploy:
     provider: heroku
     api_key: 7cf2c57e-3333-43e0-bbfa-1172c957e0d2

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ deploy:
     api_key: 7cf2c57e-3333-43e0-bbfa-1172c957e0d2
     app: 
        master:iMoGRAM
-       sprint1-Config-25:iMoGRAM
+       sprint1-Config-25:iMoGRAM-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ deploy:
     app: 
        master:iMoGRAM
        sprint1-Config-25:iMoGRAM-test
+    on: sprint1-Config-25

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: groovy
 jdk:
   - oraclejdk7
-script: ./grailsw refresh-dependencies
-  && ./grailsw "test-app unit:"
-  && ./grailsw refresh-dependencies
-  && ./grailsw "test-app functional:"
-
-  deploy:
-  provider: heroku
-  api_key: 7cf2c57e-3333-43e0-bbfa-1172c957e0d2
+script: ./grailsw refresh-dependencies && ./grailsw test-app
+deploy:
+    provider: heroku
+    api_key: 7cf2c57e-3333-43e0-bbfa-1172c957e0d2
+    app: iMoGRAM

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ jdk:
   - oraclejdk7
 script: 
       - ./grailsw refresh-dependencies
-      - ./grailsw test-app -coverage
+      - ./grailsw test-app -echoOut -echoErr -coverage -xml
 after_success:
       - ./grailsw coveralls
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,7 @@ script: ./grailsw refresh-dependencies
   && ./grailsw "test-app unit:"
   && ./grailsw refresh-dependencies
   && ./grailsw "test-app functional:"
+
+  deploy:
+  provider: heroku
+  api_key: 7cf2c57e-3333-43e0-bbfa-1172c957e0d2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: groovy
 jdk:
   - oraclejdk7
-script: ./grailsw refresh-dependencies && ./grailsw test-app
+script: 
+      - ./grailsw refresh-dependencies
+      - ./grailsw test-app -coverage
 deploy:
     provider: heroku
     api_key: 7cf2c57e-3333-43e0-bbfa-1172c957e0d2
-    app: 
-       master:iMoGRAM
-       sprint1-Config-25:iMoGRAM-test
-    on: sprint1-Config-25
+    app: imogram

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,6 @@ script: ./grailsw refresh-dependencies && ./grailsw test-app
 deploy:
     provider: heroku
     api_key: 7cf2c57e-3333-43e0-bbfa-1172c957e0d2
-    app: iMoGRAM
+    app: 
+       master:iMoGRAM
+       sprint1-Config-25:iMoGRAM

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -51,6 +51,10 @@ grails.project.dependency.resolution = {
         // runtime 'mysql:mysql-connector-java:5.1.27'
         // runtime 'org.postgresql:postgresql:9.3-1100-jdbc41'
         test "org.grails:grails-datastore-test-support:1.0-grails-2.3"
+        // Latest httpcore and httpmime for Coveralls plugin
+        build 'org.apache.httpcomponents:httpcore:4.3.2'
+        build 'org.apache.httpcomponents:httpclient:4.3.2'
+        build 'org.apache.httpcomponents:httpmime:4.3.3'
     }
 
     plugins {
@@ -60,6 +64,11 @@ grails.project.dependency.resolution = {
         // plugins for the compile step
         compile ":scaffolding:2.0.3"
         compile ':cache:1.1.7'
+
+        // Coveralls plugin
+        build(':coveralls:0.1.3', ':rest-client-builder:1.0.3') {
+            export = false
+        }
 
         test ":code-coverage:2.0.3-3"
 


### PR DESCRIPTION
- Ajout de la configuration de Heroku
- Ajout de la configuration de Coveralls -> permet de voir la couverture de code directement sur GitHub et d'avoir une couverture minimale
